### PR TITLE
Allow defining options starting with capital letters

### DIFF
--- a/spec/wiki/accessing_values_spec.cr
+++ b/spec/wiki/accessing_values_spec.cr
@@ -100,6 +100,19 @@ module OptargAccessingValuesWikiFeature
         result[String]["--class"].should eq "foo"
       end
     end
+
+    module AllowCapitalLetters
+      class Model < Optarg::Model
+        bool %w(-V --version)
+      end
+
+      it name do
+        result = Model.parse(%w(-V))
+        result.class.should eq Model
+        result.version?.should be_true
+        result[Bool]["-V"].should be_true
+      end
+    end
   end
 
   module AccessingNamelessArguments

--- a/src/lib/model/macros/value.cr
+++ b/src/lib/model/macros/value.cr
@@ -6,7 +6,7 @@ module Optarg
         kind = kind.id
         metaclass = metaclass.resolve
         names = [names] unless names.class_name == "ArrayLiteral"
-        method_names = names.map{|i| i.split("=")[0].gsub(/^-*/, "").gsub(/-/, "_").id}
+        method_names = names.map { |i| i.split("=")[0].gsub(/^-*/, "").gsub(/-/, "_").id }.reject { |n| n =~ /\A[A-Z]/ }
         value_key = value_key || names[0]
         key = names[0].id
         model_reserved = (::Optarg::Model.methods + ::Reference.methods + ::Object.methods).map{|i| i.name}


### PR DESCRIPTION
Having options and flags starting with a capital letter is relatively frequent (`optarg` supports it for the convention of using it to negate the lowercase version). Currently, defining it independently doesn't work (as it tries to dinamically generate an invalid method name):

```crystal
require "optarg"

class Parser < Optarg::Model
  bool ["-V", "--version"]
end
```

```
Error in opts.cr:4: expanding macro

  bool ["-V", "--version"]
  ^

in macro 'bool' /home/sergio/Code/crul/lib/optarg/src/lib/model/dsl/bool.cr:4, line 1:

>  1.       __define_static_value :option, :predicate, ::Optarg::Definitions::BoolOption, ["-V", "--version"], nil, nil do  |klass|
   2.         option = klass.new(["-V", "--version"], metadata: nil, stop: nil, default: nil)
   3.         @@__klass.definitions << option
   4.         
   5.         
   6.       end
   7.     

macro didn't expand to a valid program, it expanded to:

================================================================================
--------------------------------------------------------------------------------
   1.       
   2. 
   3.       
   4.         
   5.       
   6. 
   7.       
   8.         
   9.           
  10.             # Returns the -V option value.
  11.             #
  12.             # This method is automatically defined by the optarg library.
  13.             def V?
  14.               !!self[::Optarg::Definitions::BoolOption::Typed::Type]["-V"]?
  15.             end
  16.           
  17.                                                          
  18.                                                          
  19.                                                          
  20.                                                          
  21.                                                          
  22.                                                          
  23.             # Returns the -V option value.               
  24.             #                                            
  25.             # This method is automatically defined by the optarg library.
  26.             def version?                                 
  27.               !!self[::Optarg::Definitions::BoolOption::Typed::Type]["-V"]?
  28.             end
  29.           
  30.         
  31.         
  32.         
  33.       
  34. 
  35.       ::Parser.__with_self(::Optarg::Definitions::BoolOption) do |klass|
  36.   option = klass.new(["-V", "--version"], metadata: nil, stop: nil, default: nil)
  37.   @@__klass.definitions << option
  38. end
  39.     
--------------------------------------------------------------------------------
Syntax error in expanded macro: __define_static_value:13: unexpected token: NEWLINE

            def V?
                  ^

================================================================================
```

In the implementation, I just skip the generation of that method, following the same rationale as when reserved words are used (`--class`) that the value is still available through the hash lookup, or if we defined any synonym. The regular expression could be expanded to catch other valid options that generate invalid method names (numbers come to mind), but I kept it as simple as possible for my use case. Feel free to expand it (or ask me to do it).