### PR TITLE
Fix message when array option is MissingValue

### DIFF
--- a/spec/internal_spec.cr
+++ b/spec/internal_spec.cr
@@ -99,12 +99,18 @@ module OptargInternalFeature
 
   class MissingModel < Optarg::Model
     string "-s"
+    array "-a"
   end
 
   describe "Missing Value" do
     it "-s" do
       argv = %w(-s)
-      expect_raises(Optarg::MissingValue) { MissingModel.parse(argv) }
+      expect_raises(Optarg::MissingValue, "The -s option has no value") { MissingModel.parse(argv) }
+    end
+
+    it "-a" do
+      argv = %w(-a)
+      expect_raises(Optarg::MissingValue, "The -a option has no value") { MissingModel.parse(argv) }
     end
   end
 

--- a/src/lib/definitions/string_array_option.cr
+++ b/src/lib/definitions/string_array_option.cr
@@ -9,7 +9,7 @@ module Optarg::Definitions
     end
 
     def visit(parser)
-      raise MissingValue.new(parser, self, self) if parser.left < 2
+      raise MissingValue.new(parser, self, parser[0]) if parser.left < 2
       parser.args[Typed::Type][value_key] << parser[1]
       Parser.new_node(parser[0..1], self)
     end


### PR DESCRIPTION
It was showing something ugly like `The #<Optarg::Definitions::StringArrayOption:0x55e917fd0d80> option has no value.`. I don't totally understand the fix but I saw it was working correctly in string options and copied it :roll_eyes: 