### PR TITLE
Annotate return types of abstract methods

### DIFF
--- a/src/lib/definition_mixins/argument.cr
+++ b/src/lib/definition_mixins/argument.cr
@@ -6,11 +6,11 @@ module Optarg::DefinitionMixins
       module ArgumentModule
         abstract def visitable?(parser) : Bool
 
-        def completion_length(gen)
+        def completion_length(gen) : Int32
           1
         end
 
-        def completion_max_occurs(gen)
+        def completion_max_occurs(gen) : Int32
           1
         end
       end

--- a/src/lib/definition_mixins/option.cr
+++ b/src/lib/definition_mixins/option.cr
@@ -8,7 +8,7 @@ module Optarg::DefinitionMixins
       include ::Optarg::DefinitionMixins::VisitConcatenated
 
       module OptionModule
-        def completion_max_occurs(gen)
+        def completion_max_occurs(gen) : Int32
           1
         end
       end

--- a/src/lib/definitions/bool_option.cr
+++ b/src/lib/definitions/bool_option.cr
@@ -17,11 +17,11 @@ module Optarg::Definitions
       visit parser, name
     end
 
-    def completion_length(gen)
+    def completion_length(gen) : Int32
       1
     end
 
-    def completion_max_occurs(gen)
+    def completion_max_occurs(gen) : Int32
       default_value.get? == true ? 0 : 1
     end
   end

--- a/src/lib/definitions/handler.cr
+++ b/src/lib/definitions/handler.cr
@@ -2,7 +2,7 @@ module Optarg::Definitions
   abstract class Handler < Base
     include DefinitionMixins::Option
 
-    def completion_length(gen)
+    def completion_length(gen) : Int32
       1
     end
   end

--- a/src/lib/definitions/not_option.cr
+++ b/src/lib/definitions/not_option.cr
@@ -23,11 +23,11 @@ module Optarg::Definitions
       visit parser, name
     end
 
-    def completion_length(gen)
+    def completion_length(gen) : Int32
       1
     end
 
-    def completion_max_occurs(gen)
+    def completion_max_occurs(gen) : Int32
       bool.default_value.get? == true ? 1 : 0
     end
   end

--- a/src/lib/definitions/string_argument.cr
+++ b/src/lib/definitions/string_argument.cr
@@ -8,7 +8,7 @@ module Optarg::Definitions
       initialize_scalar_value_argument default: default, required: required, any_of: any_of
     end
 
-    def visitable?(parser)
+    def visitable?(parser) : Bool
       !parser.args[Typed::Type].has_key?(value_key)
     end
 

--- a/src/lib/definitions/string_array_argument.cr
+++ b/src/lib/definitions/string_array_argument.cr
@@ -9,7 +9,7 @@ module Optarg::Definitions
       initialize_completion complete
     end
 
-    def visitable?(parser)
+    def visitable?(parser) : Bool
       true
     end
 

--- a/src/lib/definitions/string_array_option.cr
+++ b/src/lib/definitions/string_array_option.cr
@@ -14,7 +14,7 @@ module Optarg::Definitions
       Parser.new_node(parser[0..1], self)
     end
 
-    def completion_length(gen)
+    def completion_length(gen) : Int32
       2
     end
   end

--- a/src/lib/definitions/string_option.cr
+++ b/src/lib/definitions/string_option.cr
@@ -18,7 +18,7 @@ module Optarg::Definitions
       raise UnsupportedConcatenation.new(parser, self)
     end
 
-    def completion_length(gen)
+    def completion_length(gen) : Int32
       2
     end
   end

--- a/src/lib/definitions/terminator.cr
+++ b/src/lib/definitions/terminator.cr
@@ -10,11 +10,11 @@ module Optarg::Definitions
       Parser.new_node(parser[0..0], self)
     end
 
-    def completion_length(gen)
+    def completion_length(gen) : Int32
       1
     end
 
-    def completion_max_occurs(gen)
+    def completion_max_occurs(gen) : Int32
       1
     end
   end

--- a/src/lib/definitions/unknown.cr
+++ b/src/lib/definitions/unknown.cr
@@ -4,11 +4,11 @@ module Optarg::Definitions
       super "@unknown", metadata: metadata, unknown: true
     end
 
-    def completion_length(gen)
+    def completion_length(gen) : Int32
       1
     end
 
-    def completion_max_occurs(gen)
+    def completion_max_occurs(gen) : Int32
       1
     end
   end


### PR DESCRIPTION
This was detected while upgrading to Crystal 0.30.0

Although they are backward compatible due to dependencies an updated `mosop/callback` should be required in shards.yml

Ref: https://github.com/mosop/callback/pull/2